### PR TITLE
fix: fixes navbar and footer render when returning from registration

### DIFF
--- a/pages/_app.pg.tsx
+++ b/pages/_app.pg.tsx
@@ -13,7 +13,10 @@ function App({ Component, pageProps }: AppProps) {
 	const showCompo = useRef(true);
 	if (["/register"].includes(router.route)) {
 		showCompo.current = false;
+	} else {
+		showCompo.current = true;
 	}
+
 	return (
 		<React.Fragment>
 			<Head>


### PR DESCRIPTION
Resolves #33 

When navigating to `/register` page, `showCompo.current` is set to `false`.    
This causes the header and footer to never display again until full refresh.

```html
{showCompo.current && <Header />}
<Component {...pageProps} />
{showCompo.current && <Footer />}
```

Setting `showCompo.current = true` when the route is not `/register` resolves this issue.
