### PR TITLE
fix: restrict hitting tab on register input fields

### DIFF
--- a/pages/register/components/RegistrationForm.tsx
+++ b/pages/register/components/RegistrationForm.tsx
@@ -133,6 +133,8 @@ export const RegistrationForm: FC<IRegistrationForm> = ({
 						return (
 							<Box ref={boxRef} key={"field-" + i} sx={{ minWidth: "100%" }}>
 								<InputField
+									tabIndex={-1}
+									disabled={stepsCompleted < i}
 									label={label}
 									name={fieldName}
 									value={formData[fieldName]}


### PR DESCRIPTION
Resolves #47 
## The Problem
Hitting tab when on any of the registration input fields would focus on the next input field, as demonstrated below
Before hitting tab:
![image](https://user-images.githubusercontent.com/63297841/193472193-2c6b5407-82ee-4b45-8e18-e702cc02f213.png)

After hitting tab:
![image](https://user-images.githubusercontent.com/63297841/193472151-43c970cb-7900-486a-be9c-07c7ad047b59.png)

The document layout has all of the fields arranged in a row fashion; hitting tab will allow focus on the next field without validating the current one, thus bypassing the `stepsCompleted` counter and moving to the next step without incrementing it.

## The Solution:
Disable all the fields whose index is greater than the steps completed. This ensures that none of the other fields get focused until the user has validated the current one. Also, a `tabIndex` of -1 was added to ensure that none of the fields are keyboard-tab focusable as a measure. 

Kindly review the PR, and any feedback or change suggestions would be appreciated.