### PR TITLE
fix: fixes header render flickering

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -46,7 +46,11 @@ export const Header: FC<IHeader> = ({ allowPadding }) => {
 					})}
 					elevation={0}
 				>
-					{!width || width < 1200 ? <HeaderMobile /> : <HeaderDesktop />}
+					{(() => {
+						if (width) {
+							return width < 1200 ? <HeaderMobile /> : <HeaderDesktop />;
+						}
+					})()}
 				</Paper>
 			</header>
 			<div

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -46,11 +46,7 @@ export const Header: FC<IHeader> = ({ allowPadding }) => {
 					})}
 					elevation={0}
 				>
-					{(() => {
-						if (width) {
-							return width < 1200 ? <HeaderMobile /> : <HeaderDesktop />;
-						}
-					})()}
+					{!width || width < 1200 ? <HeaderMobile /> : <HeaderDesktop />}
 				</Paper>
 			</header>
 			<div


### PR DESCRIPTION
Resolves #46 

On page navigation, the width of the webpage gets recalculated - this causes the "flickering" effect.
To prevent flickering, `width` must exist prior to loading `<HeaderMobile />` or `<HeaderDesktop />` component.

